### PR TITLE
docs: remove sidebar from jekyll theme

### DIFF
--- a/docs/_sass/custom/custom.scss
+++ b/docs/_sass/custom/custom.scss
@@ -1,0 +1,7 @@
+.side-bar {
+  display: none;
+}
+
+.main {
+  margin: auto;
+}


### PR DESCRIPTION
Since there is only one page, the sidebar seems unnecessary for this documentation site.

https://pmarsceill.github.io/just-the-docs/docs/customization/#override-and-completely-custom-styles