### PR TITLE
feat: validation for schema attributes + validating custom objects

### DIFF
--- a/src/components/container-form/attribute-validation-input.js
+++ b/src/components/container-form/attribute-validation-input.js
@@ -1,0 +1,109 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { useApplicationContext } from '@commercetools-frontend/application-shell-connectors';
+import {
+  DateInput,
+  DateTimeInput,
+  NumberInput,
+  TextInput,
+} from '@commercetools-uikit/inputs';
+import { ErrorMessage } from '@commercetools-uikit/messages';
+import Spacings from '@commercetools-uikit/spacings';
+import { TYPES, VALIDATION } from './constants';
+
+const AttributeValidationInput = ({
+  validation,
+  type,
+  name,
+  value,
+  touched,
+  errors,
+  onChange,
+  onBlur,
+}) => {
+  const { user } = useApplicationContext();
+  const { timeZone } = user;
+
+  switch (validation) {
+    case VALIDATION.Matches.method:
+      return (
+        <Spacings.Stack scale="xs">
+          <TextInput
+            isRequired
+            name={name}
+            value={value}
+            hasError={!!(touched && errors)}
+            onChange={onChange}
+            onBlur={onBlur}
+          />
+          {touched && errors && <ErrorMessage>{errors}</ErrorMessage>}
+        </Spacings.Stack>
+      );
+
+    case VALIDATION.Length.method:
+    case VALIDATION.Min.method:
+    case VALIDATION.Max.method:
+    case VALIDATION.LessThan.method:
+    case VALIDATION.MoreThan.method: {
+      const getInput = () => {
+        switch (type) {
+          case TYPES.Date:
+            return (
+              <DateInput
+                isRequired
+                name={name}
+                value={value}
+                hasError={!!(touched && errors)}
+                onChange={onChange}
+                onBlur={onBlur}
+              />
+            );
+          case TYPES.DateTime:
+            return (
+              <DateTimeInput
+                isRequired
+                timeZone={timeZone}
+                name={name}
+                value={value}
+                hasError={!!(touched && errors)}
+                onChange={onChange}
+                onBlur={onBlur}
+              />
+            );
+          default:
+            return (
+              <NumberInput
+                isRequired
+                name={name}
+                value={value}
+                hasError={!!(touched && errors)}
+                onChange={onChange}
+                onBlur={onBlur}
+              />
+            );
+        }
+      };
+      return (
+        <Spacings.Stack scale="xs">
+          {getInput()}
+          {touched && errors && <ErrorMessage>{errors}</ErrorMessage>}
+        </Spacings.Stack>
+      );
+    }
+    default:
+      return <span></span>;
+  }
+};
+AttributeValidationInput.displayName = 'AttributeValidationInput';
+AttributeValidationInput.propTypes = {
+  validation: PropTypes.string,
+  type: PropTypes.string.isRequired,
+  name: PropTypes.string.isRequired,
+  value: PropTypes.any,
+  touched: PropTypes.any,
+  errors: PropTypes.any,
+  onChange: PropTypes.func.isRequired,
+  onBlur: PropTypes.func.isRequired,
+};
+
+export default AttributeValidationInput;

--- a/src/components/container-form/attribute-validation.js
+++ b/src/components/container-form/attribute-validation.js
@@ -1,0 +1,208 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import filter from 'lodash/filter';
+import find from 'lodash/find';
+import get from 'lodash/get';
+import { FormattedMessage, useIntl } from 'react-intl';
+import { FieldArray } from 'formik';
+import {
+  SecondaryButton,
+  SecondaryIconButton,
+} from '@commercetools-uikit/buttons';
+import Constraints from '@commercetools-uikit/constraints';
+import { customProperties } from '@commercetools-uikit/design-system';
+import FieldLabel from '@commercetools-uikit/field-label';
+import Grid from '@commercetools-uikit/grid';
+import { BinLinearIcon, PlusBoldIcon } from '@commercetools-uikit/icons';
+import { SelectInput } from '@commercetools-uikit/inputs';
+import { ErrorMessage } from '@commercetools-uikit/messages';
+import Spacings from '@commercetools-uikit/spacings';
+import Text from '@commercetools-uikit/text';
+import AttributeValidationInput from './attribute-validation-input';
+import { VALIDATION, VALIDATION_TYPES } from './constants';
+import messages from './messages';
+import nestedStyles from './nested-attributes.mod.css';
+import styles from './attribute-validation.mod.css';
+
+const validationOptions = [
+  {
+    value: VALIDATION.Min.method,
+    label: <FormattedMessage {...messages.minValidationLabel} />,
+  },
+  {
+    value: VALIDATION.Max.method,
+    label: <FormattedMessage {...messages.maxValidationLabel} />,
+  },
+  {
+    value: VALIDATION.Length.method,
+    label: <FormattedMessage {...messages.lengthValidationLabel} />,
+  },
+  {
+    value: VALIDATION.Email.method,
+    label: <FormattedMessage {...messages.emailValidationLabel} />,
+  },
+  {
+    value: VALIDATION.Url.method,
+    label: <FormattedMessage {...messages.urlValidationLabel} />,
+  },
+  {
+    value: VALIDATION.Matches.method,
+    label: <FormattedMessage {...messages.matchesValidationLabel} />,
+  },
+  {
+    value: VALIDATION.LessThan.method,
+    label: <FormattedMessage {...messages.lessThanValidationLabel} />,
+  },
+  {
+    value: VALIDATION.MoreThan.method,
+    label: <FormattedMessage {...messages.moreThanValidationLabel} />,
+  },
+  {
+    value: VALIDATION.Integer.method,
+    label: <FormattedMessage {...messages.integerValidationLabel} />,
+  },
+  {
+    value: VALIDATION.Positive.method,
+    label: <FormattedMessage {...messages.positiveValidationLabel} />,
+  },
+  {
+    value: VALIDATION.Negative.method,
+    label: <FormattedMessage {...messages.negativeValidationLabel} />,
+  },
+];
+
+const mapTypeToValidationOptions = (type) =>
+  filter(validationOptions, (option) => {
+    const validations = VALIDATION_TYPES[type];
+    return !!find(validations, { method: option.value });
+  });
+
+const AttributeValidation = ({
+  type,
+  name,
+  value,
+  touched,
+  errors,
+  onChange,
+  onBlur,
+}) => {
+  const intl = useIntl();
+  return (
+    <div className={nestedStyles.nested}>
+      <FieldArray
+        name={name}
+        render={({ push, remove }) => (
+          <Spacings.Stack scale="s">
+            <FieldLabel
+              title={<FormattedMessage {...messages.validationTitle} />}
+            />
+            <Constraints.Horizontal constraint="scale">
+              <SecondaryButton
+                label={intl.formatMessage(messages.addValidationButton)}
+                iconLeft={<PlusBoldIcon />}
+                onClick={() =>
+                  push({
+                    type: '',
+                    value: '',
+                  })
+                }
+              />
+            </Constraints.Horizontal>
+            {value && value.length > 0 ? (
+              <Grid
+                gridRowGap={customProperties.spacingS}
+                gridColumnGap={customProperties.spacingM}
+                gridTemplateColumns={`repeat(3, 1fr)`}
+                justifyItems="start"
+              >
+                <FieldLabel
+                  title={<FormattedMessage {...messages.validationTypeTitle} />}
+                  hasRequiredIndicator
+                />
+                <FieldLabel
+                  title={
+                    <FormattedMessage {...messages.validationValueTitle} />
+                  }
+                  hasRequiredIndicator
+                />
+                <span></span>
+                {value.map((validation, index) => {
+                  const typeTouched = get(touched, `${index}.type`);
+                  const typeErrors = get(errors, `${index}.type`);
+                  return (
+                    <React.Fragment key={index}>
+                      <div className={styles.fullWidth}>
+                        <Spacings.Stack scale="xs">
+                          <SelectInput
+                            name={`${name}.${index}.type`}
+                            value={validation.type}
+                            horizontalConstraint="scale"
+                            options={mapTypeToValidationOptions(type)}
+                            hasError={!!(typeTouched && typeErrors)}
+                            onChange={onChange}
+                            onBlur={onBlur}
+                          />
+
+                          {typeTouched && typeErrors && (
+                            <ErrorMessage>{typeErrors}</ErrorMessage>
+                          )}
+                        </Spacings.Stack>
+                      </div>
+                      <div className={styles.fullWidth}>
+                        <AttributeValidationInput
+                          validation={validation.type}
+                          type={type}
+                          name={`${name}.${index}.value`}
+                          value={validation.value}
+                          touched={get(touched, `${index}.value`)}
+                          errors={get(errors, `${index}.value`)}
+                          onChange={onChange}
+                          onBlur={onBlur}
+                        />
+                      </div>
+                      <SecondaryIconButton
+                        data-testid={`remove-validation-${index}`}
+                        icon={<BinLinearIcon />}
+                        label={intl.formatMessage(messages.removeLabel)}
+                        onClick={() => remove(index)}
+                      />
+                    </React.Fragment>
+                  );
+                })}
+              </Grid>
+            ) : (
+              <Text.Body intlMessage={messages.noValidationLabel} />
+            )}
+          </Spacings.Stack>
+        )}
+      />
+    </div>
+  );
+};
+AttributeValidation.displayName = 'AttributeValidation';
+AttributeValidation.propTypes = {
+  type: PropTypes.string.isRequired,
+  name: PropTypes.string.isRequired,
+  value: PropTypes.arrayOf(
+    PropTypes.shape({
+      type: PropTypes.string,
+      value: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+    })
+  ),
+  touched: PropTypes.arrayOf(
+    PropTypes.shape({
+      type: PropTypes.bool,
+      value: PropTypes.bool,
+    })
+  ),
+  errors: PropTypes.arrayOf(
+    PropTypes.shape({
+      type: PropTypes.string,
+      value: PropTypes.string,
+    })
+  ),
+  onChange: PropTypes.func.isRequired,
+  onBlur: PropTypes.func.isRequired,
+};
+
+export default AttributeValidation;

--- a/src/components/container-form/attribute-validation.mod.css
+++ b/src/components/container-form/attribute-validation.mod.css
@@ -1,0 +1,3 @@
+.fullWidth {
+  width: 100%;
+}

--- a/src/components/container-form/attribute.js
+++ b/src/components/container-form/attribute.js
@@ -1,5 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import includes from 'lodash/includes';
+import keys from 'lodash/keys';
 import { FormattedMessage, useIntl } from 'react-intl';
 import { IconButton, SecondaryIconButton } from '@commercetools-uikit/buttons';
 import { SelectField, TextField } from '@commercetools-uikit/fields';
@@ -8,9 +10,10 @@ import { CheckboxInput } from '@commercetools-uikit/inputs';
 import Spacings from '@commercetools-uikit/spacings';
 import Text from '@commercetools-uikit/text';
 import Tooltip from '@commercetools-uikit/tooltip';
-import { ATTRIBUTES, TYPES } from './constants';
+import { ATTRIBUTES, TYPES, VALIDATION_TYPES } from './constants';
 import messages from './messages';
 import styles from './attribute.mod.css';
+import AttributeValidation from './attribute-validation';
 
 const typeOptions = [
   {
@@ -77,6 +80,7 @@ const Attribute = ({
   const intl = useIntl();
   const isRequiredDisabled =
     value.type === TYPES.Object || value.type === TYPES.Boolean;
+  const hasValidationOptions = includes(keys(VALIDATION_TYPES), value.type);
 
   React.useEffect(() => {
     if (isRequiredDisabled) {
@@ -87,85 +91,100 @@ const Attribute = ({
   }, [value.type]);
 
   return (
-    <Spacings.Inline alignItems="center" justifyContent="space-between">
-      <div className={styles.attribute}>
-        <TextField
-          name={`${name}.${ATTRIBUTES.Name}`}
-          title={<FormattedMessage {...messages.nameTitle} />}
-          horizontalConstraint="m"
-          isRequired
-          value={value.name}
-          touched={touched.name}
-          errors={errors.name}
+    <Spacings.Stack scale="s">
+      <Spacings.Inline alignItems="center" justifyContent="space-between">
+        <div className={styles.attribute}>
+          <TextField
+            name={`${name}.${ATTRIBUTES.Name}`}
+            title={<FormattedMessage {...messages.nameTitle} />}
+            horizontalConstraint="m"
+            isRequired
+            value={value.name}
+            touched={touched.name}
+            errors={errors.name}
+            onChange={handleChange}
+            onBlur={handleBlur}
+            renderError={(key, error) => error}
+          />
+          <SelectField
+            name={`${name}.${ATTRIBUTES.Type}`}
+            title={<FormattedMessage {...messages.typeTitle} />}
+            horizontalConstraint="m"
+            isRequired
+            value={value.type}
+            touched={touched.type}
+            errors={errors.type}
+            options={typeOptions}
+            onChange={handleChange}
+            onBlur={handleBlur}
+            renderError={(key, error) => error}
+          />
+          <Spacings.Stack scale="s">
+            <Spacings.Inline alignItems="center">
+              <Text.Body isBold intlMessage={messages.attributeSettingsTitle} />
+              <Tooltip
+                title={intl.formatMessage(messages.attributeSettingsHint)}
+              >
+                <IconButton
+                  label={intl.formatMessage(messages.attributeSettingsTitle)}
+                  icon={<InformationIcon />}
+                  size="small"
+                />
+              </Tooltip>
+            </Spacings.Inline>
+            <Spacings.Inline alignItems="center">
+              <CheckboxInput
+                data-testid="attribute-required"
+                name={`${name}.${ATTRIBUTES.Required}`}
+                value={JSON.stringify(value.required)}
+                isChecked={value.required}
+                isDisabled={isRequiredDisabled}
+                onChange={handleChange}
+                onBlur={handleBlur}
+              >
+                <FormattedMessage {...messages.requiredTitle} />
+              </CheckboxInput>
+              <CheckboxInput
+                name={`${name}.${ATTRIBUTES.Set}`}
+                value={JSON.stringify(value.set)}
+                isChecked={value.set}
+                onChange={handleChange}
+                onBlur={handleBlur}
+              >
+                <FormattedMessage {...messages.setTitle} />
+              </CheckboxInput>
+              <CheckboxInput
+                name={`${name}.${ATTRIBUTES.Display}`}
+                value={JSON.stringify(value.display)}
+                isDisabled={isDisplayed}
+                isChecked={value.display}
+                onChange={handleChange}
+                onBlur={handleBlur}
+              >
+                <FormattedMessage {...messages.displayTitle} />
+              </CheckboxInput>
+            </Spacings.Inline>
+          </Spacings.Stack>
+        </div>
+        <SecondaryIconButton
+          icon={<BinLinearIcon />}
+          label={intl.formatMessage(messages.removeAttributeButton)}
+          onClick={remove}
+          isDisabled={removeDisabled}
+        />
+      </Spacings.Inline>
+      {hasValidationOptions && (
+        <AttributeValidation
+          type={value.type}
+          name={`${name}.${ATTRIBUTES.Validation}`}
+          value={value.validation}
+          touched={touched.validation}
+          errors={errors.validation}
           onChange={handleChange}
           onBlur={handleBlur}
-          renderError={(key, error) => error}
         />
-        <SelectField
-          name={`${name}.${ATTRIBUTES.Type}`}
-          title={<FormattedMessage {...messages.typeTitle} />}
-          horizontalConstraint="m"
-          isRequired
-          value={value.type}
-          touched={touched.type}
-          errors={errors.type}
-          options={typeOptions}
-          onChange={handleChange}
-          onBlur={handleBlur}
-          renderError={(key, error) => error}
-        />
-        <Spacings.Stack scale="s">
-          <Spacings.Inline alignItems="center">
-            <Text.Body isBold intlMessage={messages.attributeSettingsTitle} />
-            <Tooltip title={intl.formatMessage(messages.attributeSettingsHint)}>
-              <IconButton
-                label={intl.formatMessage(messages.attributeSettingsTitle)}
-                icon={<InformationIcon />}
-                size="small"
-              />
-            </Tooltip>
-          </Spacings.Inline>
-          <Spacings.Inline alignItems="center">
-            <CheckboxInput
-              data-testid="attribute-required"
-              name={`${name}.${ATTRIBUTES.Required}`}
-              value={JSON.stringify(value.required)}
-              isChecked={value.required}
-              isDisabled={isRequiredDisabled}
-              onChange={handleChange}
-              onBlur={handleBlur}
-            >
-              <FormattedMessage {...messages.requiredTitle} />
-            </CheckboxInput>
-            <CheckboxInput
-              name={`${name}.${ATTRIBUTES.Set}`}
-              value={JSON.stringify(value.set)}
-              isChecked={value.set}
-              onChange={handleChange}
-              onBlur={handleBlur}
-            >
-              <FormattedMessage {...messages.setTitle} />
-            </CheckboxInput>
-            <CheckboxInput
-              name={`${name}.${ATTRIBUTES.Display}`}
-              value={JSON.stringify(value.display)}
-              isDisabled={isDisplayed}
-              isChecked={value.display}
-              onChange={handleChange}
-              onBlur={handleBlur}
-            >
-              <FormattedMessage {...messages.displayTitle} />
-            </CheckboxInput>
-          </Spacings.Inline>
-        </Spacings.Stack>
-      </div>
-      <SecondaryIconButton
-        icon={<BinLinearIcon />}
-        label={intl.formatMessage(messages.removeAttributeButton)}
-        onClick={remove}
-        isDisabled={removeDisabled}
-      />
-    </Spacings.Inline>
+      )}
+    </Spacings.Stack>
   );
 };
 Attribute.displayName = 'Attribute';
@@ -177,16 +196,34 @@ Attribute.propTypes = {
     required: PropTypes.bool,
     set: PropTypes.bool,
     display: PropTypes.bool,
+    validation: PropTypes.arrayOf(
+      PropTypes.shape({
+        type: PropTypes.string,
+        value: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+      })
+    ),
   }).isRequired,
   touched: PropTypes.shape({
     name: PropTypes.bool,
     type: PropTypes.bool,
     required: PropTypes.bool,
     set: PropTypes.bool,
+    validation: PropTypes.arrayOf(
+      PropTypes.shape({
+        type: PropTypes.bool,
+        value: PropTypes.bool,
+      })
+    ),
   }).isRequired,
   errors: PropTypes.shape({
     name: PropTypes.object,
     type: PropTypes.object,
+    validation: PropTypes.arrayOf(
+      PropTypes.shape({
+        type: PropTypes.string,
+        value: PropTypes.string,
+      })
+    ),
   }).isRequired,
   handleChange: PropTypes.func.isRequired,
   handleBlur: PropTypes.func.isRequired,

--- a/src/components/container-form/constants.js
+++ b/src/components/container-form/constants.js
@@ -1,3 +1,5 @@
+import messages from './messages';
+
 export const TYPES = {
   String: 'String',
   LocalizedString: 'LocalizedString',
@@ -49,8 +51,83 @@ export const ATTRIBUTES = {
   Required: 'required',
   Set: 'set',
   Display: 'display',
+  Validation: 'validation',
   Attributes: 'attributes',
   Reference: 'reference',
   Enum: 'enum',
   LocalizedEnum: 'lenum',
+};
+
+export const VALIDATION = {
+  Min: { method: 'min', hasValue: true, message: messages.minQuantityError },
+  Max: { method: 'max', hasValue: true, message: messages.maxQuantityError },
+  Length: {
+    method: 'length',
+    hasValue: true,
+    message: messages.lengthError,
+  },
+  Email: {
+    method: 'email',
+    hasValue: false,
+    message: messages.emailError,
+  },
+  Url: { method: 'url', hasValue: false, message: messages.urlError },
+  Matches: {
+    method: 'matches',
+    hasValue: true,
+    message: messages.matchesError,
+  },
+  LessThan: {
+    method: 'lessThan',
+    hasValue: true,
+    message: messages.lessThanError,
+  },
+  MoreThan: {
+    method: 'moreThan',
+    hasValue: true,
+    message: messages.moreThanError,
+  },
+  Integer: {
+    method: 'integer',
+    hasValue: false,
+    message: messages.integerError,
+  },
+  Positive: {
+    method: 'positive',
+    hasValue: false,
+    message: messages.positiveError,
+  },
+  Negative: {
+    method: 'negative',
+    hasValue: false,
+    message: messages.negativeError,
+  },
+};
+
+const stringValidation = [
+  VALIDATION.Min,
+  VALIDATION.Max,
+  VALIDATION.Length,
+  VALIDATION.Email,
+  VALIDATION.Url,
+  VALIDATION.Matches,
+];
+const numberValidation = [
+  VALIDATION.Min,
+  VALIDATION.Max,
+  VALIDATION.LessThan,
+  VALIDATION.MoreThan,
+  VALIDATION.Integer,
+  VALIDATION.Positive,
+  VALIDATION.Negative,
+];
+const dateValidation = [VALIDATION.Min, VALIDATION.Max];
+
+export const VALIDATION_TYPES = {
+  [TYPES.String]: stringValidation,
+  [TYPES.LocalizedString]: stringValidation,
+  [TYPES.Number]: numberValidation,
+  [TYPES.Money]: numberValidation,
+  [TYPES.Date]: dateValidation,
+  [TYPES.DateTime]: dateValidation,
 };

--- a/src/components/container-form/container-form.js
+++ b/src/components/container-form/container-form.js
@@ -3,11 +3,12 @@ import PropTypes from 'prop-types';
 import { useIntl } from 'react-intl';
 import { Formik } from 'formik';
 import * as yup from 'yup';
+import find from 'lodash/find';
 import reduce from 'lodash/reduce';
 import { useApplicationContext } from '@commercetools-frontend/application-shell-connectors';
 import Form from './form';
+import { TYPES, VALIDATION } from './constants';
 import messages from './messages';
-import { TYPES } from './constants';
 
 const initializeContainerValues = ({ key, value }) => ({
   key,
@@ -23,6 +24,7 @@ const initializeEmptyValues = () => ({
       set: false,
       required: false,
       display: false,
+      validation: [],
     },
   ],
 });
@@ -47,6 +49,15 @@ const ContainerForm = ({ container, onSubmit }) => {
     set: yup.bool(),
     required: yup.bool(),
     display: yup.bool(),
+    validation: yup.array(
+      yup.object({
+        type: yup.string().required(requiredFieldMessage),
+        value: yup.string().when('type', {
+          is: (val) => val && find(VALIDATION, { method: val }).hasValue,
+          then: yup.string().required(requiredFieldMessage),
+        }),
+      })
+    ),
     attributes: yup.array(yup.lazy(() => yup.object(attributeSchema))),
     reference: yup.object().when('type', {
       is: (val) => val === TYPES.Reference,

--- a/src/components/container-form/messages.js
+++ b/src/components/container-form/messages.js
@@ -167,6 +167,86 @@ export default defineMessages({
     description: 'Label for enum localized label label',
     defaultMessage: 'Label ({language})',
   },
+  validationTitle: {
+    id: 'Container.form.validation.title',
+    description: 'Title for validation field',
+    defaultMessage: 'Validation',
+  },
+  validationTypeTitle: {
+    id: 'Container.form.validation.type.title',
+    description: 'Title for validation type field',
+    defaultMessage: 'Type',
+  },
+  validationValueTitle: {
+    id: 'Container.form.validation.value.title',
+    description: 'Title for validation value field',
+    defaultMessage: 'Value',
+  },
+  addValidationButton: {
+    id: 'Container.form.validation.add.button',
+    description: 'Label for add validation button',
+    defaultMessage: 'Add Validation',
+  },
+  noValidationLabel: {
+    id: 'Container.form.validation.none',
+    description: 'Label for no validation',
+    defaultMessage: 'No additional validation for attribute.',
+  },
+  minValidationLabel: {
+    id: 'Container.form.validation.min.label',
+    description: 'Label for minimum validation',
+    defaultMessage: 'Minimum',
+  },
+  maxValidationLabel: {
+    id: 'Container.form.validation.max.label',
+    description: 'Label for maximum validation',
+    defaultMessage: 'Maximum',
+  },
+  lengthValidationLabel: {
+    id: 'Container.form.validation.length.label',
+    description: 'Label for length validation',
+    defaultMessage: 'Length',
+  },
+  emailValidationLabel: {
+    id: 'Container.form.validation.min.label',
+    description: 'Label for email validation',
+    defaultMessage: 'Email',
+  },
+  urlValidationLabel: {
+    id: 'Container.form.validation.url.label',
+    description: 'Label for url validation',
+    defaultMessage: 'URL',
+  },
+  matchesValidationLabel: {
+    id: 'Container.form.validation.matches.label',
+    description: 'Label for matches validation',
+    defaultMessage: 'Matches (regex)',
+  },
+  lessThanValidationLabel: {
+    id: 'Container.form.validation.lessThan.label',
+    description: 'Label for less than validation',
+    defaultMessage: 'Less than',
+  },
+  moreThanValidationLabel: {
+    id: 'Container.form.validation.moreThan.label',
+    description: 'Label for more than validation',
+    defaultMessage: 'More than',
+  },
+  integerValidationLabel: {
+    id: 'Container.form.validation.integer.label',
+    description: 'Label for integer validation',
+    defaultMessage: 'Integer',
+  },
+  positiveValidationLabel: {
+    id: 'Container.form.validation.positive.label',
+    description: 'Label for positive validation',
+    defaultMessage: 'Positive',
+  },
+  negativeValidationLabel: {
+    id: 'Container.form.validation.negative.label',
+    description: 'Label for negative validation',
+    defaultMessage: 'Negative',
+  },
   addLabel: {
     id: 'Container.form.add.button',
     description: 'Label for add button',
@@ -186,5 +266,60 @@ export default defineMessages({
     id: 'Container.form.error.required',
     description: 'The error message for required fields',
     defaultMessage: 'This field is required. Provide a value.',
+  },
+  minQuantityError: {
+    id: 'Container.form.error.minQuantity',
+    description: 'Error message for quantity minimum',
+    defaultMessage: 'Field must greater than or equal to {value}.',
+  },
+  maxQuantityError: {
+    id: 'Container.form.errors.maxQuantity',
+    description: 'Error message for quantity maximum',
+    defaultMessage: 'Field must less than or equal to {value}.',
+  },
+  moreThanError: {
+    id: 'Container.form.error.moreThan',
+    description: 'Error message for quantity minimum',
+    defaultMessage: 'Field must greater than {value}.',
+  },
+  lessThanError: {
+    id: 'Container.form.errors.lessThan',
+    description: 'Error message for quantity maximum',
+    defaultMessage: 'Field must less than {value}.',
+  },
+  integerError: {
+    id: 'Container.form.errors.integer',
+    description: 'Error message for integer',
+    defaultMessage: 'Field must be an integer.',
+  },
+  positiveError: {
+    id: 'Container.form.errors.positive',
+    description: 'Error message for positive',
+    defaultMessage: 'Field must be positive.',
+  },
+  negativeError: {
+    id: 'Container.form.errors.negative',
+    description: 'Error message for negative',
+    defaultMessage: 'Field must be negative.',
+  },
+  lengthError: {
+    id: 'Container.form.errors.negative',
+    description: 'Error message for negative',
+    defaultMessage: 'Field must be have a length of {value}.',
+  },
+  emailError: {
+    id: 'Container.form.errors.email',
+    description: 'Error message for negative',
+    defaultMessage: 'Field must be an email.',
+  },
+  urlError: {
+    id: 'Container.form.errors.url',
+    description: 'Error message for negative',
+    defaultMessage: 'Field must be a URL.',
+  },
+  matchesError: {
+    id: 'Container.form.errors.match',
+    description: 'Error message for matches (regex)',
+    defaultMessage: 'Field must match format {value}.',
   },
 });


### PR DESCRIPTION
Closes #6 

[Example Schema with Validation](http://localhost:3001/sparkles-sunrise/custom-objects/containers/7354ab7f-9928-4578-8e07-c9e69f103a7f/general)

**Done:**

- Validation types on schema creation
  - Only displaying validation when the attribute type has validation options
  - Changing the validation options based on the attribute type
  - The correct input types based on the validation option
  - Error handling (validation type and value are required)
- Most validation implementation for custom objects

**Remaining Work:**

- [ ] Ensure money validation types work (untested, but my guess is they don't work given the format of money values)
- [ ] Set validation (min/max)
- [ ] Fix alignment of validation type with error message on container schema form
  ![image](https://user-images.githubusercontent.com/8136478/92162143-af32b200-edff-11ea-980b-7d1d3b82e142.png)
- [ ] The matches validation assumes that the user enters a regex without the enclosing slashes (`(hi|bye)` instead of `/(hi|bye)/`). Maybe this needs some form validation or helper text.
- [ ] Format value of date and date times displayed in error messages on custom object form
  ![image](https://user-images.githubusercontent.com/8136478/92162343-0769b400-ee00-11ea-9229-aab8bb302515.png)
- [ ] Tests everywhere
- [ ] Update data model documentation (I've been using [Skitch](https://apps.apple.com/us/app/skitch-snap-mark-up-share/id425955336?mt=12) to do the annotations)
